### PR TITLE
Removed unnecessary BLUETOOTH_ADMIN permission on Android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -29,7 +29,6 @@
 
 		<config-file target="AndroidManifest.xml" parent="/*">
 			<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-			<uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/> 
 			<uses-permission android:name="android.permission.BLUETOOTH"/>
 			<uses-permission android:name="android.permission.WAKE_LOCK" />
 			<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />


### PR DESCRIPTION
Fix for #21  - BLUETOOTH_ADMIN permission on Android has been accidentally added. This commit just removes the permission from plugin.xml.