### PR TITLE
Change/mhubrath/webview crash recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .vscode
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .vscode
 .idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ updates to npm to make life easier for everyone.
 
 ## Installation
 - Current release
-`cordova plugin add cordova-plugin-music-controls2`
+`cordova plugin add @andeo/cordova-plugin-music-controls2`
 - Bleeding edge direct from github
-`cordova plugin add https://github.com/ghenry22/cordova-plugin-music-controls2`
+`cordova plugin add https://github.com/andeodev/cordova-plugin-music-controls2`
 
 ## Methods
 - Create the media controls:
@@ -138,6 +138,41 @@ Allows you to listen for iOS events fired from the scrubber in control center.
 MusicControls.updateElapsed({
 	elapsed: 208, // seconds
 	isPlaying: true
+});
+```
+
+- Battery optimization (Android only)
+
+Request to disable battery optimizations for this app.  This will show a popup for the user to confirm.
+
+```javascript
+MusicControls.disableBatteryOptimizations();
+```
+
+`MusicControls.disableBatteryOptimizations()` requires an additional permission to work, add this to your config.xml:
+
+```xml
+<platform name="android">
+    <config-file target="AndroidManifest.xml" parent="/manifest">
+        <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
+    </config-file>
+</platform>
+```
+
+Alternatively, the following opens the settings for the battery optimization, but the user has to select the app 
+manually.  However, this does not require the additional permission:
+
+```javascript
+MusicControls.openBatteryOptimizationSettings();
+```
+
+Check if battery optimizations are enabled:
+
+```javascript
+MusicControls.checkBatteryOptimizations(function (status) {
+    // status is either
+    // 'enabled' Battery optimization is enabled (the default, unless changed).
+    // 'disabled' Batter optimization is disabled.
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ MusicControls.create({
 	hasClose  : true,		// show close button, optional, default: false
 
 	// iOS only, optional
-	
+
 	duration : 60, // optional, default: 0
 	elapsed : 10, // optional, default: 0
   	hasSkipForward : true, //optional, default: false. true value overrides hasNext.
   	hasSkipBackward : true, //optional, default: false. true value overrides hasPrev.
   	skipForwardInterval : 15, //optional. default: 0.
 	skipBackwardInterval : 15, //optional. default: 0.
-	hasScrubbing : false, //optional. default to false. Enable scrubbing from control center progress bar 
+	hasScrubbing : false, //optional. default to false. Enable scrubbing from control center progress bar
 
 	// Android only, optional
 	// text displayed in the status bar when the notification (and the ticker) are updated
@@ -159,7 +159,7 @@ MusicControls.disableBatteryOptimizations();
 </platform>
 ```
 
-Alternatively, the following opens the settings for the battery optimization, but the user has to select the app 
+Alternatively, the following opens the settings for the battery optimization, but the user has to select the app
 manually.  However, this does not require the additional permission:
 
 ```javascript
@@ -176,7 +176,7 @@ MusicControls.checkBatteryOptimizations(function (status) {
 });
 ```
 
-## List of media button events 
+## List of media button events
 - Default:
 ```javascript
 'music-controls-media-button'

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ updates to npm to make life easier for everyone.
 ## Supported platforms
 - Android (4.1+) ([homerours](https://github.com/homerours))
 - Windows (10+, by [filfat](https://github.com/filfat))
-- iOS 8+ (by [0505gonzalez](https://github.com/0505gonzalez))
+- iOS 15+
 
 ## Installation
 - Current release
@@ -87,6 +87,9 @@ function events(action) {
 			// Do something
 			break;
 		case 'music-controls-destroy':
+			// Do something
+			break;
+		case 'music-controls-stop-listening':
 			// Do something
 			break;
     	case 'music-controls-toggle-play-pause' :
@@ -193,10 +196,18 @@ MusicControls.checkBatteryOptimizations(function (status) {
 'music-controls-media-button-headset-hook'
 ```
 
-- iOS Only:
+- iOS only:
 ```javascript
-'music-controls-skip-forward', 'music-controls-skip-backward'
+'music-controls-skip-forward', 'music-controls-skip-backward', 'music-controls-stop-listening'
 ```
+
+## Compatibility notes
+
+### cordova-ios 8.1.1+
+
+cordova-ios 8.1.1 changed the `WKScriptMessageHandler` from `CDVViewController` to `CDVWebViewEngine` (fix [#1664](https://github.com/apache/cordova-ios/pull/1664)). This altered the JS→native dispatch path and exposed a race condition in the plugin's previous one-shot callback re-registration pattern: after each lock screen button press, the callbackId was invalidated on the JS side, requiring a `cordova.exec('watch')` round-trip before the next press. Under the new dispatch path this round-trip could arrive too late when the app was backgrounded, causing all subsequent button presses to silently no-op.
+
+Fixed by setting `keepCallback = YES` on all `MPRemoteCommandCenter` and `UIEvent` handlers so the callbackId stays permanently valid and no re-registration is needed after each event.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andeo/cordova-plugin-music-controls2",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "description": "Music controls for Cordova apps",
   "cordova": {
     "id": "@andeo/cordova-plugin-music-controls2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andeo/cordova-plugin-music-controls2",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Music controls for Cordova apps",
   "cordova": {
     "id": "@andeo/cordova-plugin-music-controls2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   ],
   "author": "ghenry22",
   "license": "MIT",
+  "types": "./types/index.d.ts",
   "bugs": {
     "url": "https://github.com/andeodev/cordova-plugin-music-controls2/issues"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andeo/cordova-plugin-music-controls2",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Music controls for Cordova apps",
   "cordova": {
     "id": "@andeo/cordova-plugin-music-controls2",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "cordova-plugin-music-controls2",
-  "version": "3.0.7",
+  "name": "@andeo/cordova-plugin-music-controls2",
+  "version": "1.0.0",
   "description": "Music controls for Cordova apps",
   "cordova": {
-    "id": "cordova-plugin-music-controls2",
+    "id": "@andeo/cordova-plugin-music-controls2",
     "platforms": ["android", "windows", "ios"]
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ghenry22/cordova-plugin-music-controls2.git"
+    "url": "git+https://github.com/andeodev/cordova-plugin-music-controls2.git"
   },
   "keywords": [
     "cordova",
@@ -31,8 +31,8 @@
   "author": "ghenry22",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/ghenry22/cordova-plugin-music-controls2/issues"
+    "url": "https://github.com/andeodev/cordova-plugin-music-controls2/issues"
   },
   "homepage":
-    "https://github.com/ghenry22/cordova-plugin-music-controls2#readme"
+    "https://github.com/andeodev/cordova-plugin-music-controls2#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andeo/cordova-plugin-music-controls2",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Music controls for Cordova apps",
   "cordova": {
     "id": "@andeo/cordova-plugin-music-controls2",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,14 @@
 {
   "name": "@andeo/cordova-plugin-music-controls2",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Music controls for Cordova apps",
   "cordova": {
     "id": "@andeo/cordova-plugin-music-controls2",
-    "platforms": ["android", "windows", "ios"]
+    "platforms": [
+      "android",
+      "windows",
+      "ios"
+    ]
   },
   "repository": {
     "type": "git",
@@ -34,6 +38,5 @@
   "bugs": {
     "url": "https://github.com/andeodev/cordova-plugin-music-controls2/issues"
   },
-  "homepage":
-    "https://github.com/andeodev/cordova-plugin-music-controls2#readme"
+  "homepage": "https://github.com/andeodev/cordova-plugin-music-controls2#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andeo/cordova-plugin-music-controls2",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Music controls for Cordova apps",
   "cordova": {
     "id": "@andeo/cordova-plugin-music-controls2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andeo/cordova-plugin-music-controls2",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Music controls for Cordova apps",
   "cordova": {
     "id": "@andeo/cordova-plugin-music-controls2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andeo/cordova-plugin-music-controls2",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Music controls for Cordova apps",
   "cordova": {
     "id": "@andeo/cordova-plugin-music-controls2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andeo/cordova-plugin-music-controls2",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Music controls for Cordova apps",
   "cordova": {
     "id": "@andeo/cordova-plugin-music-controls2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andeo/cordova-plugin-music-controls2",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Music controls for Cordova apps",
   "cordova": {
     "id": "@andeo/cordova-plugin-music-controls2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andeo/cordova-plugin-music-controls2",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Music controls for Cordova apps",
   "cordova": {
     "id": "@andeo/cordova-plugin-music-controls2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andeo/cordova-plugin-music-controls2",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Music controls for Cordova apps",
   "cordova": {
     "id": "@andeo/cordova-plugin-music-controls2",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android"
-	id="cordova-plugin-music-controls2"
-	version="3.0.7">
+	id="@andeo/cordova-plugin-music-controls2"
+	version="1.0.0">
 	<name>Music Controls</name>
 	<keywords>cordova,music,controller,controls,media,plugin,notification,lockscreen,now,playing</keywords>
-	<repo>https://github.com/ghenry22/cordova-plugin-music-controls2</repo>
+	<repo>https://github.com/andeodev/cordova-plugin-music-controls2</repo>
 	<description>Music controls for Cordova apps</description>
 	<license>MIT</license>
 	<author>ghenry22</author>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android"
 	id="@andeo/cordova-plugin-music-controls2"
-	version="1.0.12">
+	version="1.0.13">
 	<name>Music Controls</name>
 	<keywords>cordova,music,controller,controls,media,plugin,notification,lockscreen,now,playing</keywords>
 	<repo>https://github.com/andeodev/cordova-plugin-music-controls2</repo>

--- a/plugin.xml
+++ b/plugin.xml
@@ -36,7 +36,7 @@
 		</config-file>
 
 		<config-file target="AndroidManifest.xml" parent="/manifest/application">
-			<service android:name="com.homerours.musiccontrols.MusicControlsNotificationKiller" android:stopWithTask="true" android:foregroundServiceType="mediaPlayback"></service>
+			<service android:name="com.homerours.musiccontrols.MusicControlsNotificationKiller" android:stopWithTask="false" android:foregroundServiceType="mediaPlayback"></service>
 		</config-file>
 
 		<framework src="com.android.support:support-v4:28.0.0" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android"
 	id="@andeo/cordova-plugin-music-controls2"
-	version="1.0.11">
+	version="1.0.12">
 	<name>Music Controls</name>
 	<keywords>cordova,music,controller,controls,media,plugin,notification,lockscreen,now,playing</keywords>
 	<repo>https://github.com/andeodev/cordova-plugin-music-controls2</repo>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android"
 	id="@andeo/cordova-plugin-music-controls2"
-	version="1.0.9">
+	version="1.0.11">
 	<name>Music Controls</name>
 	<keywords>cordova,music,controller,controls,media,plugin,notification,lockscreen,now,playing</keywords>
 	<repo>https://github.com/andeodev/cordova-plugin-music-controls2</repo>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android"
 	id="@andeo/cordova-plugin-music-controls2"
-	version="1.0.0">
+	version="1.0.9">
 	<name>Music Controls</name>
 	<keywords>cordova,music,controller,controls,media,plugin,notification,lockscreen,now,playing</keywords>
 	<repo>https://github.com/andeodev/cordova-plugin-music-controls2</repo>

--- a/src/android/MusicControls.java
+++ b/src/android/MusicControls.java
@@ -278,7 +278,11 @@ public class MusicControls extends CordovaPlugin {
 				PlaybackStateCompat.ACTION_PLAY_FROM_SEARCH);
 			playbackstateBuilder.setState(state, PlaybackStateCompat.PLAYBACK_POSITION_UNKNOWN, 0);
 		}
-		this.mediaSessionCompat.setPlaybackState(playbackstateBuilder.build());
+		try {
+		    this.mediaSessionCompat.setPlaybackState(playbackstateBuilder.build());
+		} catch (Exception ex) {
+            ex.printStackTrace();
+        }
 	}
 
 	// Get image from url

--- a/src/android/MusicControls.java
+++ b/src/android/MusicControls.java
@@ -67,7 +67,7 @@ public class MusicControls extends CordovaPlugin {
 
 		// Listen for headset plug/unplug
 		context.registerReceiver((BroadcastReceiver)mMessageReceiver, new IntentFilter(Intent.ACTION_HEADSET_PLUG));
-		
+
 		// Listen for bluetooth connection state changes
 		context.registerReceiver((BroadcastReceiver)mMessageReceiver, new IntentFilter(android.bluetooth.BluetoothHeadset.ACTION_CONNECTION_STATE_CHANGED));
 	}
@@ -118,7 +118,7 @@ public class MusicControls extends CordovaPlugin {
 		this.mMessageReceiver = new MusicControlsBroadcastReceiver(this);
 		this.registerBroadcaster(mMessageReceiver);
 
-		
+
 		this.mediaSessionCompat = new MediaSessionCompat(context, "cordova-music-controls-media-session", null, this.mediaButtonPendingIntent);
 		this.mediaSessionCompat.setFlags(MediaSessionCompat.FLAG_HANDLES_MEDIA_BUTTONS | MediaSessionCompat.FLAG_HANDLES_TRANSPORT_CONTROLS);
 
@@ -141,7 +141,7 @@ public class MusicControls extends CordovaPlugin {
 				mConnection.setNotification(null, false);
 			}
 		};
-		
+
 		// Register media (headset) button event receiver
 		try {
 			this.mAudioManager = (AudioManager)context.getSystemService(Context.AUDIO_SERVICE);
@@ -166,7 +166,7 @@ public class MusicControls extends CordovaPlugin {
 		final Context context=this.cordova.getActivity().getApplicationContext();
 		final Activity activity=this.cordova.getActivity();
 
-		
+
 		if (action.equals("create")) {
 			final MusicControlsInfos infos = new MusicControlsInfos(args);
 			 final MediaMetadataCompat.Builder metadataBuilder = new MediaMetadataCompat.Builder();
@@ -175,7 +175,7 @@ public class MusicControls extends CordovaPlugin {
 			this.cordova.getThreadPool().execute(new Runnable() {
 				public void run() {
 					notification.updateNotification(infos);
-					
+
 					// track title
 					metadataBuilder.putString(MediaMetadataCompat.METADATA_KEY_TITLE, infos.track);
 					// artists
@@ -205,12 +205,12 @@ public class MusicControls extends CordovaPlugin {
 			final JSONObject params = args.getJSONObject(0);
 			final boolean isPlaying = params.getBoolean("isPlaying");
 			this.notification.updateIsPlaying(isPlaying);
-			
+
 			if(isPlaying)
 				setMediaPlaybackState(PlaybackStateCompat.STATE_PLAYING);
 			else
 				setMediaPlaybackState(PlaybackStateCompat.STATE_PAUSED);
-			
+
 			callbackContext.success("success");
 		}
 		else if (action.equals("updateDismissable")){
@@ -264,7 +264,7 @@ public class MusicControls extends CordovaPlugin {
 		}
 		this.mediaSessionCompat.setPlaybackState(playbackstateBuilder.build());
 	}
-	
+
 	// Get image from url
 	private Bitmap getBitmapCover(String coverURL){
 		try{

--- a/src/android/MusicControls.java
+++ b/src/android/MusicControls.java
@@ -4,6 +4,7 @@ import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CordovaWebView;
+import org.apache.cordova.LOG;
 import org.apache.cordova.PluginResult;
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/src/android/MusicControls.java
+++ b/src/android/MusicControls.java
@@ -156,6 +156,7 @@ public class MusicControls extends CordovaPlugin {
 		try {
 			this.mAudioManager = (AudioManager)context.getSystemService(Context.AUDIO_SERVICE);
 			Intent headsetIntent = new Intent("music-controls-media-button");
+			headsetIntent.setPackage(context.getPackageName());
 			this.mediaButtonPendingIntent = PendingIntent.getBroadcast(
 				context, 0, headsetIntent,
 				Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE : PendingIntent.FLAG_UPDATE_CURRENT

--- a/src/android/MusicControls.java
+++ b/src/android/MusicControls.java
@@ -197,6 +197,7 @@ public class MusicControls extends CordovaPlugin {
 					metadataBuilder.putString(MediaMetadataCompat.METADATA_KEY_ARTIST, infos.artist);
 					//album
 					metadataBuilder.putString(MediaMetadataCompat.METADATA_KEY_ALBUM, infos.album);
+					metadataBuilder.putLong(MediaMetadataCompat.METADATA_KEY_DURATION, secsToMs(infos.duration));
 
 					Bitmap art = getBitmapCover(infos.cover);
 					if(art != null){
@@ -207,10 +208,11 @@ public class MusicControls extends CordovaPlugin {
 
 					mediaSessionCompat.setMetadata(metadataBuilder.build());
 
+					long positionMs = secsToMs(infos.elapsed);
 					if(infos.isPlaying)
-						setMediaPlaybackState(PlaybackStateCompat.STATE_PLAYING);
+						setMediaPlaybackState(PlaybackStateCompat.STATE_PLAYING, positionMs);
 					else
-						setMediaPlaybackState(PlaybackStateCompat.STATE_PAUSED);
+						setMediaPlaybackState(PlaybackStateCompat.STATE_PAUSED, positionMs);
 
 					callbackContext.success("success");
 				}
@@ -221,10 +223,11 @@ public class MusicControls extends CordovaPlugin {
 			final boolean isPlaying = params.getBoolean("isPlaying");
 			this.notification.updateIsPlaying(isPlaying);
 
+			final long positionMs = secsToMs(params.optDouble("elapsed", 0));
 			if(isPlaying)
-				setMediaPlaybackState(PlaybackStateCompat.STATE_PLAYING);
+				setMediaPlaybackState(PlaybackStateCompat.STATE_PLAYING, positionMs);
 			else
-				setMediaPlaybackState(PlaybackStateCompat.STATE_PAUSED);
+				setMediaPlaybackState(PlaybackStateCompat.STATE_PAUSED, positionMs);
 
 			callbackContext.success("success");
 		}
@@ -276,18 +279,26 @@ public class MusicControls extends CordovaPlugin {
 		onDestroy();
 		super.onReset();
 	}
+	private static long secsToMs(double secs) {
+		return (long)(secs * 1000);
+	}
+
 	private void setMediaPlaybackState(int state) {
+		setMediaPlaybackState(state, PlaybackStateCompat.PLAYBACK_POSITION_UNKNOWN);
+	}
+
+	private void setMediaPlaybackState(int state, long positionMs) {
 		PlaybackStateCompat.Builder playbackstateBuilder = new PlaybackStateCompat.Builder();
 		if( state == PlaybackStateCompat.STATE_PLAYING ) {
 			playbackstateBuilder.setActions(PlaybackStateCompat.ACTION_PLAY_PAUSE | PlaybackStateCompat.ACTION_PAUSE | PlaybackStateCompat.ACTION_SKIP_TO_NEXT | PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS |
 				PlaybackStateCompat.ACTION_PLAY_FROM_MEDIA_ID |
 				PlaybackStateCompat.ACTION_PLAY_FROM_SEARCH);
-			playbackstateBuilder.setState(state, PlaybackStateCompat.PLAYBACK_POSITION_UNKNOWN, 1.0f);
+			playbackstateBuilder.setState(state, positionMs, 1.0f);
 		} else {
 			playbackstateBuilder.setActions(PlaybackStateCompat.ACTION_PLAY_PAUSE | PlaybackStateCompat.ACTION_PLAY | PlaybackStateCompat.ACTION_SKIP_TO_NEXT | PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS |
 				PlaybackStateCompat.ACTION_PLAY_FROM_MEDIA_ID |
 				PlaybackStateCompat.ACTION_PLAY_FROM_SEARCH);
-			playbackstateBuilder.setState(state, PlaybackStateCompat.PLAYBACK_POSITION_UNKNOWN, 0);
+			playbackstateBuilder.setState(state, positionMs, 0);
 		}
 		try {
 		    this.mediaSessionCompat.setPlaybackState(playbackstateBuilder.build());

--- a/src/android/MusicControls.java
+++ b/src/android/MusicControls.java
@@ -56,6 +56,11 @@ public class MusicControls extends CordovaPlugin {
 	private boolean mediaButtonAccess=true;
 	private android.media.session.MediaSession.Token token;
 
+	// Cover-art cache: avoids re-downloading the same image on every create() call
+	// (e.g. the 300 ms Android retry and seek-triggered updates all use the same URL).
+	private String cachedCoverUrl = null;
+	private Bitmap cachedCoverBitmap = null;
+
   	private Activity cordovaActivity;
 
 	private MediaSessionCallback mMediaSessionCallback = new MediaSessionCallback();
@@ -307,16 +312,25 @@ public class MusicControls extends CordovaPlugin {
         }
 	}
 
-	// Get image from url
+	// Get image from url, with a single-entry cache keyed on the URL.
 	private Bitmap getBitmapCover(String coverURL){
+		if (coverURL == null || coverURL.isEmpty()) {
+			cachedCoverUrl = null;
+			cachedCoverBitmap = null;
+			return null;
+		}
+		if (coverURL.equals(cachedCoverUrl) && cachedCoverBitmap != null) {
+			return cachedCoverBitmap;
+		}
 		try{
+			Bitmap bitmap;
 			if(coverURL.matches("^(https?|ftp)://.*$"))
-				// Remote image
-				return getBitmapFromURL(coverURL);
-			else {
-				// Local image
-				return getBitmapFromLocal(coverURL);
-			}
+				bitmap = getBitmapFromURL(coverURL);
+			else
+				bitmap = getBitmapFromLocal(coverURL);
+			cachedCoverUrl = coverURL;
+			cachedCoverBitmap = bitmap;
+			return bitmap;
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			return null;

--- a/src/android/MusicControls.java
+++ b/src/android/MusicControls.java
@@ -38,6 +38,8 @@ import android.content.BroadcastReceiver;
 import android.media.AudioManager;
 import android.provider.Settings;
 import android.view.View;
+import android.webkit.RenderProcessGoneDetail;
+import android.webkit.WebView;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -60,6 +62,10 @@ public class MusicControls extends CordovaPlugin {
 	// (e.g. the 300 ms Android retry and seek-triggered updates all use the same URL).
 	private String cachedCoverUrl = null;
 	private Bitmap cachedCoverBitmap = null;
+
+	// WebView crash recovery: survives renderer death because this plugin runs in the main app process.
+	private long webviewKilledAt = 0;
+	private String storedPlaybackState = null;
 
   	private Activity cordovaActivity;
 
@@ -268,6 +274,38 @@ public class MusicControls extends CordovaPlugin {
 			else
 				callbackContext.success("disabled");
 		}
+		else if (action.equals("storePlaybackState")) {
+			try {
+				JSONObject payload = args.getJSONObject(0);
+				this.storedPlaybackState = payload.toString();
+				callbackContext.success("ok");
+			} catch (JSONException e) {
+				callbackContext.error("Invalid payload");
+			}
+		}
+		else if (action.equals("getRecoveryData")) {
+			if (this.webviewKilledAt == 0 || this.storedPlaybackState == null) {
+				callbackContext.success("null");
+				return true;
+			}
+			try {
+				JSONObject result = new JSONObject(this.storedPlaybackState);
+				result.put("killedAt", this.webviewKilledAt);
+				this.webviewKilledAt = 0;
+				callbackContext.success(result.toString());
+			} catch (JSONException e) {
+				this.webviewKilledAt = 0;
+				callbackContext.success("null");
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
+		this.webviewKilledAt = System.currentTimeMillis();
+		LOG.w("MusicControls", "WebView renderer gone (crashed=" + detail.didCrash() + "), reloading");
+		cordova.getActivity().runOnUiThread(() -> view.reload());
 		return true;
 	}
 

--- a/src/android/MusicControlsInfos.java
+++ b/src/android/MusicControlsInfos.java
@@ -24,7 +24,7 @@ public class MusicControlsInfos{
 
 	public MusicControlsInfos(JSONArray args) throws JSONException {
 		final JSONObject params = args.getJSONObject(0);
-		
+
 		this.track = params.getString("track");
 		this.artist = params.getString("artist");
     		this.album = params.getString("album");

--- a/src/android/MusicControlsInfos.java
+++ b/src/android/MusicControlsInfos.java
@@ -21,6 +21,8 @@ public class MusicControlsInfos{
 	public String nextIcon;
 	public String closeIcon;
 	public String notificationIcon;
+	public double elapsed;
+	public double duration;
 
 	public MusicControlsInfos(JSONArray args) throws JSONException {
 		final JSONObject params = args.getJSONObject(0);
@@ -41,6 +43,8 @@ public class MusicControlsInfos{
 		this.nextIcon = params.getString("nextIcon");
 		this.closeIcon = params.getString("closeIcon");
 		this.notificationIcon = params.getString("notificationIcon");
+		this.elapsed = params.optDouble("elapsed", 0);
+		this.duration = params.optDouble("duration", 0);
 	}
 
 }

--- a/src/android/MusicControlsNotification.java
+++ b/src/android/MusicControlsNotification.java
@@ -71,7 +71,7 @@ public class MusicControlsNotification {
 
 	// Show or update notification
 	public void updateNotification(MusicControlsInfos newInfos){
-		// Check if the cover has changed	
+		// Check if the cover has changed
 		if (!newInfos.cover.isEmpty() && (this.infos == null || !newInfos.cover.equals(this.infos.cover))){
 			this.getBitmapCover(newInfos.cover);
 		}
@@ -183,7 +183,7 @@ public class MusicControlsNotification {
 		if (!infos.ticker.isEmpty()){
 			builder.setTicker(infos.ticker);
 		}
-		
+
 		builder.setPriority(Notification.PRIORITY_MAX);
 
 		//If 5.0 >= set the controls to be visible on lockscreen

--- a/src/android/MusicControlsNotification.java
+++ b/src/android/MusicControlsNotification.java
@@ -175,7 +175,7 @@ public class MusicControlsNotification {
 		if (infos.dismissable){
 			builder.setOngoing(false);
 			Intent dismissIntent = new Intent("music-controls-destroy");
-			PendingIntent dismissPendingIntent = PendingIntent.getBroadcast(context, 1, dismissIntent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0);
+			PendingIntent dismissPendingIntent = PendingIntent.getBroadcast(context, 1, dismissIntent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_IMMUTABLE : 0);
 			builder.setDeleteIntent(dismissPendingIntent);
 		} else {
 			builder.setOngoing(true);
@@ -183,7 +183,7 @@ public class MusicControlsNotification {
 		if (!infos.ticker.isEmpty()){
 			builder.setTicker(infos.ticker);
 		}
-		
+
 		builder.setPriority(Notification.PRIORITY_MAX);
 
 		//If 5.0 >= set the controls to be visible on lockscreen
@@ -218,7 +218,7 @@ public class MusicControlsNotification {
 		Intent resultIntent = new Intent(context, cordovaActivity.getClass());
 		resultIntent.setAction(Intent.ACTION_MAIN);
 		resultIntent.addCategory(Intent.CATEGORY_LAUNCHER);
-		PendingIntent resultPendingIntent = PendingIntent.getActivity(context, 0, resultIntent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0);
+		PendingIntent resultPendingIntent = PendingIntent.getActivity(context, 0, resultIntent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_IMMUTABLE : 0);
 		builder.setContentIntent(resultPendingIntent);
 
 		//Controls
@@ -228,20 +228,20 @@ public class MusicControlsNotification {
 			/* Previous  */
 			nbControls++;
 			Intent previousIntent = new Intent("music-controls-previous");
-			PendingIntent previousPendingIntent = PendingIntent.getBroadcast(context, 1, previousIntent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0);
+			PendingIntent previousPendingIntent = PendingIntent.getBroadcast(context, 1, previousIntent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_IMMUTABLE : 0);
 			builder.addAction(this.getResourceId(infos.prevIcon, android.R.drawable.ic_media_previous), "", previousPendingIntent);
 		}
 		if (infos.isPlaying){
 			/* Pause  */
 			nbControls++;
 			Intent pauseIntent = new Intent("music-controls-pause");
-			PendingIntent pausePendingIntent = PendingIntent.getBroadcast(context, 1, pauseIntent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0);
+			PendingIntent pausePendingIntent = PendingIntent.getBroadcast(context, 1, pauseIntent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_IMMUTABLE : 0);
 			builder.addAction(this.getResourceId(infos.pauseIcon, android.R.drawable.ic_media_pause), "", pausePendingIntent);
 		} else {
 			/* Play  */
 			nbControls++;
 			Intent playIntent = new Intent("music-controls-play");
-			PendingIntent playPendingIntent = PendingIntent.getBroadcast(context, 1, playIntent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0);
+			PendingIntent playPendingIntent = PendingIntent.getBroadcast(context, 1, playIntent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_IMMUTABLE : 0);
 			builder.addAction(this.getResourceId(infos.playIcon, android.R.drawable.ic_media_play), "", playPendingIntent);
 		}
 
@@ -249,14 +249,14 @@ public class MusicControlsNotification {
 			/* Next */
 			nbControls++;
 			Intent nextIntent = new Intent("music-controls-next");
-			PendingIntent nextPendingIntent = PendingIntent.getBroadcast(context, 1, nextIntent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0);
+			PendingIntent nextPendingIntent = PendingIntent.getBroadcast(context, 1, nextIntent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_IMMUTABLE : 0);
 			builder.addAction(this.getResourceId(infos.nextIcon, android.R.drawable.ic_media_next), "", nextPendingIntent);
 		}
 		if (infos.hasClose){
 			/* Close */
 			nbControls++;
 			Intent destroyIntent = new Intent("music-controls-destroy");
-			PendingIntent destroyPendingIntent = PendingIntent.getBroadcast(context, 1, destroyIntent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : 0);
+			PendingIntent destroyPendingIntent = PendingIntent.getBroadcast(context, 1, destroyIntent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_IMMUTABLE : 0);
 			builder.addAction(this.getResourceId(infos.closeIcon, android.R.drawable.ic_menu_close_clear_cancel), "", destroyPendingIntent);
 		}
 

--- a/src/android/MusicControlsNotification.java
+++ b/src/android/MusicControlsNotification.java
@@ -175,6 +175,7 @@ public class MusicControlsNotification {
 		if (infos.dismissable){
 			builder.setOngoing(false);
 			Intent dismissIntent = new Intent("music-controls-destroy");
+			dismissIntent.setPackage(context.getPackageName());
 			PendingIntent dismissPendingIntent = PendingIntent.getBroadcast(context, 1, dismissIntent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_IMMUTABLE : 0);
 			builder.setDeleteIntent(dismissPendingIntent);
 		} else {
@@ -228,6 +229,7 @@ public class MusicControlsNotification {
 			/* Previous  */
 			nbControls++;
 			Intent previousIntent = new Intent("music-controls-previous");
+			previousIntent.setPackage(context.getPackageName());
 			PendingIntent previousPendingIntent = PendingIntent.getBroadcast(context, 1, previousIntent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_IMMUTABLE : 0);
 			builder.addAction(this.getResourceId(infos.prevIcon, android.R.drawable.ic_media_previous), "", previousPendingIntent);
 		}
@@ -235,12 +237,14 @@ public class MusicControlsNotification {
 			/* Pause  */
 			nbControls++;
 			Intent pauseIntent = new Intent("music-controls-pause");
+			pauseIntent.setPackage(context.getPackageName());
 			PendingIntent pausePendingIntent = PendingIntent.getBroadcast(context, 1, pauseIntent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_IMMUTABLE : 0);
 			builder.addAction(this.getResourceId(infos.pauseIcon, android.R.drawable.ic_media_pause), "", pausePendingIntent);
 		} else {
 			/* Play  */
 			nbControls++;
 			Intent playIntent = new Intent("music-controls-play");
+			playIntent.setPackage(context.getPackageName());
 			PendingIntent playPendingIntent = PendingIntent.getBroadcast(context, 1, playIntent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_IMMUTABLE : 0);
 			builder.addAction(this.getResourceId(infos.playIcon, android.R.drawable.ic_media_play), "", playPendingIntent);
 		}
@@ -249,6 +253,7 @@ public class MusicControlsNotification {
 			/* Next */
 			nbControls++;
 			Intent nextIntent = new Intent("music-controls-next");
+			nextIntent.setPackage(context.getPackageName());
 			PendingIntent nextPendingIntent = PendingIntent.getBroadcast(context, 1, nextIntent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_IMMUTABLE : 0);
 			builder.addAction(this.getResourceId(infos.nextIcon, android.R.drawable.ic_media_next), "", nextPendingIntent);
 		}
@@ -256,6 +261,7 @@ public class MusicControlsNotification {
 			/* Close */
 			nbControls++;
 			Intent destroyIntent = new Intent("music-controls-destroy");
+			destroyIntent.setPackage(context.getPackageName());
 			PendingIntent destroyPendingIntent = PendingIntent.getBroadcast(context, 1, destroyIntent, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_IMMUTABLE : 0);
 			builder.addAction(this.getResourceId(infos.closeIcon, android.R.drawable.ic_menu_close_clear_cancel), "", destroyPendingIntent);
 		}

--- a/src/android/MusicControlsNotificationKiller.java
+++ b/src/android/MusicControlsNotificationKiller.java
@@ -48,7 +48,12 @@ public class MusicControlsNotificationKiller extends Service {
 	}
 
 	public void setForeground(Notification notification) {
-		this.startForeground(this.NOTIFICATION_ID, notification);
+		try {
+		    this.startForeground(this.NOTIFICATION_ID, notification);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            return;
+        }
 
 		if (this.wakeLock == null) {
 			PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
@@ -70,7 +75,12 @@ public class MusicControlsNotificationKiller extends Service {
 		this.stopForeground(STOP_FOREGROUND_DETACH);
 
 		if (this.wakeLock != null && this.wakeLock.isHeld()) {
-			this.wakeLock.release();
+            try {
+		        this.wakeLock.release();
+		    } catch (Exception ex) {
+                ex.printStackTrace();
+                return;
+            }
 		}
 
 		LOG.d(LOG_TAG, "Service removed from foreground");

--- a/src/android/MusicControlsNotificationKiller.java
+++ b/src/android/MusicControlsNotificationKiller.java
@@ -5,6 +5,7 @@ import android.app.Service;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.Binder;
+import android.os.PowerManager;
 import android.app.NotificationManager;
 import android.content.Intent;
 
@@ -13,6 +14,8 @@ public class MusicControlsNotificationKiller extends Service {
 	private static int NOTIFICATION_ID;
 	private NotificationManager mNM;
 	private final IBinder mBinder = new KillBinder(this);
+
+	private PowerManager.WakeLock wakeLock;
 
 	@Override
 	public IBinder onBind(Intent intent) {
@@ -28,12 +31,23 @@ public class MusicControlsNotificationKiller extends Service {
 	public void onCreate() {
 		mNM = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
 		mNM.cancel(NOTIFICATION_ID);
+
+		if (this.wakeLock == null) {
+			PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
+			this.wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "Adonia::MediaPlayer");
+		}
+
+		this.wakeLock.acquire();
 	}
 
 	@Override
 	public void onDestroy() {
 		mNM = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
 		mNM.cancel(NOTIFICATION_ID);
+
+		if (this.wakeLock != null) {
+			this.wakeLock.release();
+		}
 	}
 
 	public void setForeground(Notification notification) {

--- a/src/android/MusicControlsNotificationKiller.java
+++ b/src/android/MusicControlsNotificationKiller.java
@@ -2,6 +2,7 @@ package com.homerours.musiccontrols;
 
 import android.app.Notification;
 import android.app.Service;
+import android.content.pm.ServiceInfo;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.PowerManager;
@@ -47,9 +48,13 @@ public class MusicControlsNotificationKiller extends Service {
 		LOG.d(LOG_TAG, "Service destroyed");
 	}
 
-	public void setForeground(Notification notification) {
+	public void setForeground(Notification notification, boolean isPlaying) {
 		try {
-		    this.startForeground(this.NOTIFICATION_ID, notification);
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+				this.startForeground(this.NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK);
+			} else {
+				this.startForeground(this.NOTIFICATION_ID, notification);
+			}
         } catch (Exception ex) {
             ex.printStackTrace();
             return;
@@ -60,11 +65,17 @@ public class MusicControlsNotificationKiller extends Service {
 			this.wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "Adonia::MediaPlayer");
 		}
 
-		if (!this.wakeLock.isHeld()) {
+		if (isPlaying && !this.wakeLock.isHeld()) {
 			this.wakeLock.acquire();
+		} else if (!isPlaying && this.wakeLock.isHeld()) {
+			try {
+				this.wakeLock.release();
+			} catch (Exception ex) {
+				ex.printStackTrace();
+			}
 		}
 
-		LOG.d(LOG_TAG, "Service set to foreground");
+		LOG.d(LOG_TAG, "Service set to foreground, isPlaying=" + isPlaying);
 	}
 
 	public void clearForeground() {

--- a/src/android/MusicControlsServiceConnection.java
+++ b/src/android/MusicControlsServiceConnection.java
@@ -17,7 +17,12 @@ public class MusicControlsServiceConnection implements ServiceConnection {
 
     public void onServiceConnected(ComponentName className, IBinder binder) {
         service = ((KillBinder) binder).service;
-        service.startService(new Intent(activity, MusicControlsNotificationKiller.class));
+        try {
+            service.startService(new Intent(activity, MusicControlsNotificationKiller.class));
+        }
+        catch (Exception ex) {
+            ex.printStackTrace();
+        }
     }
 
     public void onServiceDisconnected(ComponentName className) {

--- a/src/android/MusicControlsServiceConnection.java
+++ b/src/android/MusicControlsServiceConnection.java
@@ -33,8 +33,8 @@ public class MusicControlsServiceConnection implements ServiceConnection {
             return;
         }
 
-        if (isPlaying) {
-            this.service.setForeground(notification);
+        if (notification != null) {
+            this.service.setForeground(notification, isPlaying);
         } else {
             this.service.clearForeground();
         }

--- a/src/ios/CDVViewController+MusicControls.h
+++ b/src/ios/CDVViewController+MusicControls.h
@@ -1,6 +1,6 @@
 //
 //  MainViewController+MusicControls.h
-//  
+//
 //
 //  Created by Juan Gonzalez on 12/17/16.
 //

--- a/src/ios/CDVViewController+MusicControls.m
+++ b/src/ios/CDVViewController+MusicControls.m
@@ -1,6 +1,6 @@
 //
 //  MainViewController+MusicControls.m
-//  
+//
 //
 //  Created by Juan Gonzalez on 12/17/16.
 //

--- a/src/ios/MusicControls.m
+++ b/src/ios/MusicControls.m
@@ -37,6 +37,8 @@ MusicControlsInfo * musicControlsSettings;
 
         if (mediaItemArtwork != nil) {
             [updatedNowPlayingInfo setObject:mediaItemArtwork forKey:MPMediaItemPropertyArtwork];
+        } else {
+            [updatedNowPlayingInfo removeObjectForKey:MPMediaItemPropertyArtwork];
         }
 
         [updatedNowPlayingInfo setObject:[musicControlsInfo artist] forKey:MPMediaItemPropertyArtist];

--- a/src/ios/MusicControls.m
+++ b/src/ios/MusicControls.m
@@ -87,7 +87,7 @@ MusicControlsInfo * musicControlsSettings;
 - (MPMediaItemArtwork *) createCoverArtwork: (NSString *) coverUri {
     UIImage * coverImage = nil;
 
-    if (coverUri == nil) {
+    if (coverUri == nil || [coverUri isKindOfClass:[NSNull class]]) {
         return nil;
     }
 

--- a/src/ios/MusicControls.m
+++ b/src/ios/MusicControls.m
@@ -1,6 +1,6 @@
 //
 //  MusicControls.m
-//  
+//
 //
 //  Created by Juan Gonzalez on 12/16/16.
 //  Updated by Gaven Henry on 11/7/17 for iOS 11 compatibility & new features
@@ -20,32 +20,32 @@ MusicControlsInfo * musicControlsSettings;
     NSDictionary * musicControlsInfoDict = [command.arguments objectAtIndex:0];
     MusicControlsInfo * musicControlsInfo = [[MusicControlsInfo alloc] initWithDictionary:musicControlsInfoDict];
     musicControlsSettings = musicControlsInfo;
-    
+
     if (!NSClassFromString(@"MPNowPlayingInfoCenter")) {
         return;
     }
-    
+
     [self.commandDelegate runInBackground:^{
         MPNowPlayingInfoCenter * nowPlayingInfoCenter =  [MPNowPlayingInfoCenter defaultCenter];
         NSDictionary * nowPlayingInfo = nowPlayingInfoCenter.nowPlayingInfo;
         NSMutableDictionary * updatedNowPlayingInfo = [NSMutableDictionary dictionaryWithDictionary:nowPlayingInfo];
-        
+
         MPMediaItemArtwork * mediaItemArtwork = [self createCoverArtwork:[musicControlsInfo cover]];
         NSNumber * duration = [NSNumber numberWithInt:[musicControlsInfo duration]];
         NSNumber * elapsed = [NSNumber numberWithInt:[musicControlsInfo elapsed]];
         NSNumber * playbackRate = [NSNumber numberWithBool:[musicControlsInfo isPlaying]];
-        
+
         if (mediaItemArtwork != nil) {
             [updatedNowPlayingInfo setObject:mediaItemArtwork forKey:MPMediaItemPropertyArtwork];
         }
-        
+
         [updatedNowPlayingInfo setObject:[musicControlsInfo artist] forKey:MPMediaItemPropertyArtist];
         [updatedNowPlayingInfo setObject:[musicControlsInfo track] forKey:MPMediaItemPropertyTitle];
         [updatedNowPlayingInfo setObject:[musicControlsInfo album] forKey:MPMediaItemPropertyAlbumTitle];
         [updatedNowPlayingInfo setObject:duration forKey:MPMediaItemPropertyPlaybackDuration];
         [updatedNowPlayingInfo setObject:elapsed forKey:MPNowPlayingInfoPropertyElapsedPlaybackTime];
         [updatedNowPlayingInfo setObject:playbackRate forKey:MPNowPlayingInfoPropertyPlaybackRate];
-        
+
         nowPlayingInfoCenter.nowPlayingInfo = updatedNowPlayingInfo;
     }];
 
@@ -57,14 +57,14 @@ MusicControlsInfo * musicControlsSettings;
     MusicControlsInfo * musicControlsInfo = [[MusicControlsInfo alloc] initWithDictionary:musicControlsInfoDict];
     NSNumber * elapsed = [NSNumber numberWithDouble:[musicControlsInfo elapsed]];
     NSNumber * playbackRate = [NSNumber numberWithBool:[musicControlsInfo isPlaying]];
-    
+
     if (!NSClassFromString(@"MPNowPlayingInfoCenter")) {
         return;
     }
 
     MPNowPlayingInfoCenter * nowPlayingCenter = [MPNowPlayingInfoCenter defaultCenter];
     NSMutableDictionary * updatedNowPlayingInfo = [NSMutableDictionary dictionaryWithDictionary:nowPlayingCenter.nowPlayingInfo];
-    
+
     [updatedNowPlayingInfo setObject:elapsed forKey:MPNowPlayingInfoPropertyElapsedPlaybackTime];
     [updatedNowPlayingInfo setObject:playbackRate forKey:MPNowPlayingInfoPropertyPlaybackRate];
     nowPlayingCenter.nowPlayingInfo = updatedNowPlayingInfo;
@@ -86,20 +86,20 @@ MusicControlsInfo * musicControlsSettings;
 
 - (MPMediaItemArtwork *) createCoverArtwork: (NSString *) coverUri {
     UIImage * coverImage = nil;
-    
+
     if (coverUri == nil) {
         return nil;
     }
-    
+
     if ([coverUri hasPrefix:@"http://"] || [coverUri hasPrefix:@"https://"]) {
         NSURL * coverImageUrl = [NSURL URLWithString:coverUri];
         NSData * coverImageData = [NSData dataWithContentsOfURL: coverImageUrl];
-        
+
         coverImage = [UIImage imageWithData: coverImageData];
     }
     else if ([coverUri hasPrefix:@"file://"]) {
         NSString * fullCoverImagePath = [coverUri stringByReplacingOccurrencesOfString:@"file://" withString:@""];
-        
+
         if ([[NSFileManager defaultManager] fileExistsAtPath: fullCoverImagePath]) {
             coverImage = [[UIImage alloc] initWithContentsOfFile: fullCoverImagePath];
         }
@@ -107,7 +107,7 @@ MusicControlsInfo * musicControlsSettings;
     else if (![coverUri isEqual:@""]) {
         NSString * baseCoverImagePath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
         NSString * fullCoverImagePath = [NSString stringWithFormat:@"%@%@", baseCoverImagePath, coverUri];
-    
+
         if ([[NSFileManager defaultManager] fileExistsAtPath:fullCoverImagePath]) {
             coverImage = [UIImage imageNamed:fullCoverImagePath];
         }
@@ -115,7 +115,7 @@ MusicControlsInfo * musicControlsSettings;
     else {
         coverImage = [UIImage imageNamed:@"none"];
     }
-    
+
     return [self isCoverImageValid:coverImage] ? [[MPMediaItemArtwork alloc] initWithImage:coverImage] : nil;
 }
 
@@ -196,55 +196,55 @@ MusicControlsInfo * musicControlsSettings;
 //Handle all other remote control events
 - (void) handleMusicControlsNotification: (NSNotification *) notification {
     UIEvent * receivedEvent = notification.object;
-    
+
     if ([self latestEventCallbackId] == nil) {
         return;
     }
-    
+
     if (receivedEvent.type == UIEventTypeRemoteControl) {
         NSString * action;
-        
+
         switch (receivedEvent.subtype) {
             case UIEventSubtypeRemoteControlTogglePlayPause:
                 action = @"music-controls-toggle-play-pause";
                 break;
-                
+
             case UIEventSubtypeRemoteControlPlay:
                 action = @"music-controls-play";
                 break;
-                
+
             case UIEventSubtypeRemoteControlPause:
                 action = @"music-controls-pause";
                 break;
-                
+
             case UIEventSubtypeRemoteControlPreviousTrack:
                 action = @"music-controls-previous";
                 break;
-                
+
             case UIEventSubtypeRemoteControlNextTrack:
                 action = @"music-controls-next";
                 break;
-                
+
             case UIEventSubtypeRemoteControlStop:
                 action = @"music-controls-destroy";
                 break;
-                
+
             default:
                 action = nil;
                 break;
         }
-        
+
         if(action == nil){
             return;
         }
-        
+
         NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
         CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
     }
 }
 
-- (void) viewDidAppear:(BOOL)animated 
+- (void) viewDidAppear:(BOOL)animated
 {
     if ([[UIApplication sharedApplication] respondsToSelector:@selector(beginReceivingRemoteControlEvents)]){
         [[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
@@ -252,7 +252,7 @@ MusicControlsInfo * musicControlsSettings;
     }
 }
 
-- (void) viewWillDisappear:(BOOL)animated 
+- (void) viewWillDisappear:(BOOL)animated
 {
     [[UIApplication sharedApplication] endReceivingRemoteControlEvents];
     [self resignFirstResponder];
@@ -263,7 +263,7 @@ MusicControlsInfo * musicControlsSettings;
 - (void) registerMusicControlsEventListener {
     [[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleMusicControlsNotification:) name:@"musicControlsEventNotification" object:nil];
-    
+
     //register required event handlers for standard controls
     MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
     [commandCenter.playCommand setEnabled:true];
@@ -314,18 +314,18 @@ MusicControlsInfo * musicControlsSettings;
 - (void) deregisterMusicControlsEventListener {
     [[UIApplication sharedApplication] endReceivingRemoteControlEvents];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:@"receivedEvent" object:nil];
-    
+
     MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
     [commandCenter.nextTrackCommand removeTarget:self];
     [commandCenter.previousTrackCommand removeTarget:self];
-    
+
     if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_9_0) {
         [commandCenter.changePlaybackPositionCommand setEnabled:false];
         [commandCenter.changePlaybackPositionCommand removeTarget:self action:NULL];
         [commandCenter.skipForwardCommand removeTarget:self];
         [commandCenter.skipBackwardCommand removeTarget:self];
     }
-    
+
     [self setLatestEventCallbackId:nil];
 }
 

--- a/src/ios/MusicControls.m
+++ b/src/ios/MusicControls.m
@@ -135,6 +135,7 @@ MusicControlsInfo * musicControlsSettings;
     NSString * seekTo = [NSString stringWithFormat:@"{\"message\":\"music-controls-seek-to\",\"position\":\"%f\"}", event.positionTime];
     CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:seekTo];
     pluginResult.associatedObject = @{@"position":[NSNumber numberWithDouble: event.positionTime]};
+    [pluginResult setKeepCallbackAsBool:YES];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
     return MPRemoteCommandHandlerStatusSuccess;
 }
@@ -144,6 +145,7 @@ MusicControlsInfo * musicControlsSettings;
     NSString * action = @"music-controls-skip-forward";
     NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
     CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
+    [pluginResult setKeepCallbackAsBool:YES];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
     return MPRemoteCommandHandlerStatusSuccess;
 }
@@ -153,6 +155,7 @@ MusicControlsInfo * musicControlsSettings;
     NSString * action = @"music-controls-skip-backward";
     NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
     CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
+    [pluginResult setKeepCallbackAsBool:YES];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
     return MPRemoteCommandHandlerStatusSuccess;
 }
@@ -169,6 +172,7 @@ MusicControlsInfo * musicControlsSettings;
     NSString * action = @"music-controls-next";
     NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
     CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
+    [pluginResult setKeepCallbackAsBool:YES];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
     return MPRemoteCommandHandlerStatusSuccess;
 }
@@ -177,6 +181,7 @@ MusicControlsInfo * musicControlsSettings;
     NSString * action = @"music-controls-previous";
     NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
     CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
+    [pluginResult setKeepCallbackAsBool:YES];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
     return MPRemoteCommandHandlerStatusSuccess;
 
@@ -186,6 +191,7 @@ MusicControlsInfo * musicControlsSettings;
     NSString * action = @"music-controls-pause";
     NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
     CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
+    [pluginResult setKeepCallbackAsBool:YES];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
     return MPRemoteCommandHandlerStatusSuccess;
 
@@ -195,6 +201,7 @@ MusicControlsInfo * musicControlsSettings;
     NSString * action = @"music-controls-play";
     NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
     CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
+    [pluginResult setKeepCallbackAsBool:YES];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
     return MPRemoteCommandHandlerStatusSuccess;
 
@@ -247,6 +254,7 @@ MusicControlsInfo * musicControlsSettings;
 
         NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
         CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
+        [pluginResult setKeepCallbackAsBool:YES];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
     }
 }

--- a/src/ios/MusicControls.m
+++ b/src/ios/MusicControls.m
@@ -51,6 +51,11 @@ MusicControlsInfo * musicControlsSettings;
         nowPlayingInfoCenter.nowPlayingInfo = updatedNowPlayingInfo;
     }];
 
+    // Deregister before re-registering to prevent duplicate MPRemoteCommandCenter handlers.
+    // Without this, every create() call stacks another handler set on top of the previous
+    // ones; after minutes of periodic calls those duplicates fire simultaneously on each
+    // lock-screen / Bluetooth button press, crashing or corrupting playback state.
+    [self deregisterMusicControlsEventListener];
     [self registerMusicControlsEventListener];
 }
 
@@ -315,9 +320,11 @@ MusicControlsInfo * musicControlsSettings;
 
 - (void) deregisterMusicControlsEventListener {
     [[UIApplication sharedApplication] endReceivingRemoteControlEvents];
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"receivedEvent" object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"musicControlsEventNotification" object:nil];
 
     MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
+    [commandCenter.playCommand removeTarget:self];
+    [commandCenter.pauseCommand removeTarget:self];
     [commandCenter.nextTrackCommand removeTarget:self];
     [commandCenter.previousTrackCommand removeTarget:self];
 

--- a/src/ios/MusicControls.m
+++ b/src/ios/MusicControls.m
@@ -85,6 +85,7 @@ MusicControlsInfo * musicControlsSettings;
 
 - (void) destroy: (CDVInvokedUrlCommand *) command {
     [self deregisterMusicControlsEventListener];
+    [self setLatestEventCallbackId:nil];
 }
 
 - (void) watch: (CDVInvokedUrlCommand *) command {
@@ -342,8 +343,6 @@ MusicControlsInfo * musicControlsSettings;
         [commandCenter.skipForwardCommand removeTarget:self];
         [commandCenter.skipBackwardCommand removeTarget:self];
     }
-
-    [self setLatestEventCallbackId:nil];
 }
 
 - (void) dealloc {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,145 @@
+declare namespace MediaControls {
+    interface CreateOptions {
+        track?: string;
+        artist?: string;
+        album?: string;
+        cover?: string|null;
+        isPlaying?: boolean;
+        dismissable?: boolean;
+        hasPrev?: boolean;
+        hasNext?: boolean;
+        hasClose?: boolean;
+
+        // iOS only
+        duration?: number;
+        elapsed?: number;
+        hasSkipForward?: boolean;
+        hasSkipBackward?: boolean;
+        skipForwardInterval?: number;
+        skipBackwardInterval?: number;
+        hasScrubbing?: false;
+
+        // Android only
+        ticker?: string;
+        playIcon?: string;
+        pauseIcon?: string;
+        prevIcon?: string;
+        nextIcon?: string;
+        closeIcon?: string;
+        notificationIcon?: string;
+    }
+
+    type SuccessCallback = (arg: ['success']) => void;
+
+    type MediaControlErrorCallback = (err: Error) => void;
+
+    // The event callback receives a string, which is a JSON-encoded Event.  (Yes, it's stupid)
+    type EventSubscriber = (event: string) => void|Promise<void>;
+
+    type Event = {
+        message: 'music-controls-play'
+            |'music-controls-pause'
+            |'music-controls-previous'
+            |'music-controls-next'
+            |'music-controls-stop-listening'
+            |'music-controls-destroy'
+            |'music-controls-toggle-play-pause'
+            |'music-controls-seek-to'
+            |'music-controls-media-button'
+            |'music-controls-headset-unplugged'
+            |'music-controls-headset-plugged'
+
+            // Media buttons defined for Android
+            |'music-controls-media-button-next'
+            |'music-controls-media-button-pause'
+            |'music-controls-media-button-play'
+            |'music-controls-media-button-play-pause'
+            |'music-controls-media-button-previous'
+            |'music-controls-media-button-stop'
+            |'music-controls-media-button-fast-forward'
+            |'music-controls-media-button-rewind'
+            |'music-controls-media-button-skip-backward'
+            |'music-controls-media-button-skip-forward'
+            |'music-controls-media-button-step-backward'
+            |'music-controls-media-button-step-forward'
+            |'music-controls-media-button-meta-left'
+            |'music-controls-media-button-meta-right'
+            |'music-controls-media-button-music'
+            |'music-controls-media-button-volume-up'
+            |'music-controls-media-button-volume-down'
+            |'music-controls-media-button-volume-mute'
+            |'music-controls-media-button-headset-hook'
+
+            // Media buttons defined for iOS
+            |'music-controls-skip-forward'
+            |'music-controls-skip-backward';
+    };
+
+    interface UpdateElapsed {
+        elapsed: number;
+        isPlaying: boolean;
+    }
+
+    type BatteryOptimizationStatus = 'enabled'|'disabled';
+}
+
+declare var MusicControls: {
+    /**
+     * Create the media control.
+     */
+    create(
+        options: MediaControls.CreateOptions,
+        onSuccess: MediaControls.SuccessCallback,
+        onError: MediaControls.MediaControlErrorCallback,
+    ): void;
+
+    /**
+     * Destroy the media controller.
+     */
+    destroy(
+        onSuccess: MediaControls.SuccessCallback,
+        onError: MediaControls.MediaControlErrorCallback,
+    ): void;
+
+    /**
+     * Register the callback for subscribing to the media controller events.
+     */
+    subscribe(subscriber: MediaControls.EventSubscriber): void;
+
+    /**
+     * Start listening for events.
+     */
+    listen(): void;
+
+    /**
+     * Toggle play/pause.
+     */
+    updateIsPlaying(playing: boolean): void;
+
+    /**
+     * Update whether the notification is dismissable.
+     */
+    updateDismissable(dismissable: boolean): void;
+
+    /***
+     * iOS only: Allows you to listen for iOS events fired from the scrubber in control center.
+     */
+    updateElapsed(update: MediaControls.UpdateElapsed): void;
+
+    /**
+     * Request to disable battery optimizations for this app.  This will show a popup for the user to confirm.
+     *
+     * Requires additional permission: REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
+     */
+    disableBatteryOptimizations(): void;
+
+    /**
+     * Open the battery optimization settings.
+     */
+    openBatteryOptimizationSettings(): void;
+
+    /**
+     * Check if battery optimizations are enabled.
+     */
+    checkBatteryOptimizations(callback: (status: MediaControls.BatteryOptimizationStatus) => void): void;
+};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,7 +17,7 @@ declare namespace MediaControls {
         hasSkipBackward?: boolean;
         skipForwardInterval?: number;
         skipBackwardInterval?: number;
-        hasScrubbing?: false;
+        hasScrubbing?: boolean;
 
         // Android only
         ticker?: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -142,4 +142,11 @@ declare var MusicControls: {
      * Check if battery optimizations are enabled.
      */
     checkBatteryOptimizations(callback: (status: MediaControls.BatteryOptimizationStatus) => void): void;
+
+    /** Store current playback state in native memory for WebView crash recovery. Android only. */
+    storePlaybackState(data: object, onSuccess: () => void, onError: () => void): void;
+
+    /** Retrieve stored crash-recovery data. Returns null JSON string if no crash occurred. Android only. */
+    getRecoveryData(onSuccess: (data: string) => void, onError: () => void): void;
+
 };

--- a/www/MusicControls.js
+++ b/www/MusicControls.js
@@ -97,7 +97,37 @@ var musicControls = {
       "watch",
       []
     );
-  }
+  },
+
+  disableBatteryOptimizations: function() {
+    cordova.exec(
+        null,
+        null,
+        "MusicControls",
+        "disableBatteryOptimizations",
+        []
+    );
+  },
+
+  openBatteryOptimizationSettings: function() {
+    cordova.exec(
+        null,
+        null,
+        "MusicControls",
+        "openBatteryOptimizationSettings",
+        []
+    );
+  },
+
+  checkBatteryOptimizations: function(successCallback, errorCallback) {
+    cordova.exec(
+        successCallback,
+        errorCallback,
+        "MusicControls",
+        "checkBatteryOptimizations",
+        []
+    );
+  },
 };
 
 function isUndefined(val) {

--- a/www/MusicControls.js
+++ b/www/MusicControls.js
@@ -90,13 +90,6 @@ var musicControls = {
   },
   receiveCallbackFromNative: function(messageFromNative) {
     musicControls.updateCallback(messageFromNative);
-    cordova.exec(
-      musicControls.receiveCallbackFromNative,
-      function(res) {},
-      "MusicControls",
-      "watch",
-      []
-    );
   },
 
   disableBatteryOptimizations: function() {

--- a/www/MusicControls.js
+++ b/www/MusicControls.js
@@ -90,6 +90,11 @@ var musicControls = {
   },
   receiveCallbackFromNative: function(messageFromNative) {
     musicControls.updateCallback(messageFromNative);
+    // Re-arm the native watch for the next button press.
+    // The Java callbacks (MediaSessionCallback, BroadcastReceiver) null themselves after
+    // each event and callbackContext.success() sends keepCallback=false, so the Cordova
+    // bridge removes the JS handler after it fires. Re-calling listen() here restores it.
+    musicControls.listen();
   },
 
   disableBatteryOptimizations: function() {
@@ -121,6 +126,27 @@ var musicControls = {
         []
     );
   },
+
+  storePlaybackState: function(data, successCallback, errorCallback) {
+    cordova.exec(
+        successCallback,
+        errorCallback,
+        "MusicControls",
+        "storePlaybackState",
+        [data]
+    );
+  },
+
+  getRecoveryData: function(successCallback, errorCallback) {
+    cordova.exec(
+        successCallback,
+        errorCallback,
+        "MusicControls",
+        "getRecoveryData",
+        []
+    );
+  },
+
 };
 
 function isUndefined(val) {


### PR DESCRIPTION
- Re-arm listen() in receiveCallbackFromNative so lock screen/Bluetooth
  buttons keep working after the first press (keepCallback=false consumed
  the JS handler after one fire)
- Add storePlaybackState action: stores current+next track URL in native
  memory so JS state survives a WebView renderer crash
- Add getRecoveryData action: returns stored state + timestamp if a crash
  occurred, clears flag on read
- Handle onRenderProcessGone to detect renderer death and trigger reload
- Add TypeScript declarations for new plugin APIs
- Bump version to 1.0.13